### PR TITLE
Deactivate status module by default

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -142,7 +142,7 @@ LoadModule version_module modules/mod_version.so
 LoadModule unixd_module modules/mod_unixd.so
 #LoadModule heartbeat_module modules/mod_heartbeat.so
 #LoadModule heartmonitor_module modules/mod_heartmonitor.so
-LoadModule status_module modules/mod_status.so
+#LoadModule status_module modules/mod_status.so
 LoadModule autoindex_module modules/mod_autoindex.so
 #LoadModule asis_module modules/mod_asis.so
 #LoadModule info_module modules/mod_info.so


### PR DESCRIPTION
The status module exposes the `/server-status` endpoint which could potentially disclose sensitive information.